### PR TITLE
feat: Implement Mule secure property awareness

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,19 @@ This Python utility validates a MuleSoft package for dependency management, flow
 - **Flow Validation**: Validates the number of flows, sub-flows, and components in the MuleSoft package.
 - **API Validation**: Ensures the presence of API specifications and API definition flows.
 
+## MuleSoft Secure Property Awareness
+
+The validator now includes features to intelligently handle MuleSoft's secure property configurations:
+
+-   **Automatic Detection:** The validator automatically detects if your MuleSoft project is configured to use MuleSoft's standard secure properties by looking for the `<secure-properties:config ... />` element in your Mule XML configuration files.
+-   **Smarter Validation:** When secure property usage is detected project-wide, the validator adjusts its behavior for certain checks in YAML configuration files to reduce false positives and provide more relevant feedback:
+    -   **Generic Secret Patterns:** If a property value is encrypted using the MuleSoft format (e.g., `my.secret: "![encryptedValue]"`), the validator will not flag the encrypted content as a potential leaked secret. Instead, it will issue an informational message acknowledging that the value is encrypted.
+    -   **Sensitive Keywords in Property Names:** If a property name contains sensitive keywords (like `password`, `apiKey`, `secret`, `token`), and its value is correctly encrypted in the `![...]` format, the validator will treat this appropriately, often issuing an informational message instead of a high-severity warning for plaintext exposure.
+-   **Example Informational Messages:** With this feature, you might see messages like:
+    -   `INFO: Key 'some.key.name' has Mule encrypted value. Length: XX.`
+    -   `INFO: Key 'db.password' (sensitive keyword) has Mule encrypted value.` (This specific message format might vary slightly based on the exact check that identifies it, but the intent is to inform about secured sensitive keys).
+-   **Benefit:** This enhancement makes the validator more accurate for projects that correctly implement MuleSoft's secure property mechanism. It helps distinguish between actual plaintext secrets and properly secured configurations, leading to more actionable validation results.
+
 ## Installation
 
 Clone this repository and navigate to the project directory:

--- a/main.py
+++ b/main.py
@@ -1,3 +1,11 @@
+"""
+Main entry point for the MuleSoft Package Validator CLI tool.
+
+This script orchestrates the validation of a MuleSoft package by invoking various
+validators for dependencies, flows, API specifications, YAML configurations,
+MuleSoft code review, and component structure. It takes the package folder path
+as a command-line argument and prints a summary of all validation results.
+"""
 import argparse
 from mule_validator.dependency_validator import validate_dependencies_and_size
 from mule_validator.flow_validator import validate_flows_in_package
@@ -5,15 +13,33 @@ from mule_validator.code_reviewer import review_all_files
 from mule_validator.components_validator import validate_mule_package
 from mule_validator.api_validator import validate_api_spec_and_flows
 from mule_validator.configfile_validator import validate_files
+from tabulate import tabulate
 
 
 def main():
+    """
+    Main function to parse command-line arguments and orchestrate the validation
+    of a MuleSoft package.
 
+    The validation process includes:
+    1. Code Review: Analyzes Mule XML files for issues and checks for the use of
+       Mule Secure Properties. This is done first as its output (`project_uses_secure_properties`)
+       is required by the YAML configuration validator.
+    2. YAML Configuration Validation: Checks for presence, syntax, and content of
+       YAML configuration files, considering if secure properties are used.
+    3. Dependency and Build Size Validation: Validates Maven dependencies and build size.
+    4. Flow and Component Validation: Validates the structure and components within Mule flows.
+    5. API Specification and Definition Flow Validation: Checks API RAML specs against
+       their corresponding Mule flow implementations.
+    6. General Component Validation: Performs additional checks on Mule components.
+
+    Results from all validators are collected and printed in a summary.
     """
-    Main function to parse command-line arguments and validate the MuleSoft package.
-    """
-    # Create the parser
-    parser = argparse.ArgumentParser(description='Validate MuleSoft package for API specifications and definition flows.')
+    # Create the parser for command-line arguments
+    parser = argparse.ArgumentParser(
+        description='Validate a MuleSoft package, checking API specifications, '
+                    'definition flows, YAML configurations, and more.'
+    )
 
     # Add the package folder path argument
     parser.add_argument(
@@ -26,57 +52,73 @@ def main():
     args = parser.parse_args()
 
     # Define the paths to your MuleSoft package and build folder
-    #package_folder_path = 'C:/Users/venkats/OneDrive - SBS Corporation/Documents/SBS/ws/mulesoft/' + 'sbs-eis-integrationservices'
-    #build_folder_path = 'C:/Users/venkats/OneDrive - SBS Corporation/Documents/SBS/ws/mulesoft/' + 'sbs-eis-integrationservices'
+    # These are now derived from the command-line arguments.
+    # Example: package_folder_path = 'path/to/your/mulesoft/project'
+    # Example: build_folder_path = 'path/to/your/mulesoft/project' (often same as package for these validations)
     
     package_folder_path = args.package_folder_path
-    build_folder_path = args.package_folder_path
-    #1. Validate YAML Files
-    print("Validating YAML configuration files...")
-    yaml_validation_results = validate_files(package_folder_path)
+    build_folder_path = args.package_folder_path # Assuming build path is same as package path for these validators
+
+    # --- Orchestrate Validation Steps ---
+
+    # Step 1: Code Review (performed first as its output is needed by YAML validation)
+    # This reviews Mule XML files for coding standards, issues, and detects
+    # if Mule Secure Properties configuration is used anywhere in the project.
+    print("\nReviewing flows and code structure...")
+    issues_data_from_code_reviewer, project_uses_secure_properties = review_all_files(package_folder_path)
+    print("\nCode Review Issues Found:")
+    if issues_data_from_code_reviewer:
+        print(tabulate(issues_data_from_code_reviewer, headers=["File Name", "Status", "Issue"], tablefmt="grid"))
+    else:
+        print("No code review issues found.")
+    print(f"Project uses Mule Secure Properties: {project_uses_secure_properties}")
+
+    # Step 2: Validate YAML Files
+    # This validator now uses `project_uses_secure_properties` to apply specific
+    # content rules (e.g., warning if plaintext secrets are found when encryption is available).
+    print("\nValidating YAML configuration files...")
+    yaml_validation_results = validate_files(package_folder_path, project_uses_secure_properties)
     print("YAML Validation Results:", yaml_validation_results)
 
-    # 2. Validate Dependencies and Build Size
+    # Step 3: Validate Dependencies and Build Size
     print("\nValidating dependencies and build size...")
     dependency_validation_results = validate_dependencies_and_size(package_folder_path, build_folder_path)
     print("Dependency Validation Results:", dependency_validation_results)
 
-    # 3. Validate Flows and Components
+    # Step 4: Validate Flows and Components within flows
     print("\nValidating flows and components...")
     flow_validation_results = validate_flows_in_package(package_folder_path)
     print("Flow Validation Results:", flow_validation_results)
 
-    # 4. Validate API Specifications and Definition Flows
+    # Step 5: Validate API Specifications against their Definition Flows
     print("\nValidating API specifications and definition flows...")
     api_validation_results = validate_api_spec_and_flows(package_folder_path)
     print("API Validation Results:", api_validation_results)
 
-    
-    # 5. Code Review the flow definitions
-    print("\nReviewing flows...")
-    code_reviewer_results = review_all_files(package_folder_path)
-    print("Code Review Results:", code_reviewer_results)
+    # Note: Code Review (previously step 5 in some orderings) results were processed earlier.
 
-    # 6. Validate Components
+    # Step 6: Validate general Mule Components structure
     print("\nValidating Components...")
     components_validator_results = validate_mule_package(package_folder_path)
     print("Components Validation Results:", components_validator_results)
 
     
 
-    # Combine all results
+    # Combine all validation results into a single dictionary for a comprehensive summary.
     print("\nAll validations completed.")
     all_results = {
-        'yaml_validation': yaml_validation_results,
-        'dependency_validation': dependency_validation_results,
-        'flow_validation': flow_validation_results,
-        'api_validation': api_validation_results,
-        'code_reviewer' : code_reviewer_results,
-        'components_validator' : components_validator_results
+        'yaml_validation': yaml_validation_results,  # Results from YAML file checks
+        'dependency_validation': dependency_validation_results,  # Results from POM and build size checks
+        'flow_validation': flow_validation_results,  # Results from Mule flow structure checks
+        'api_validation': api_validation_results,  # Results from API spec vs. flow implementation checks
+        'code_reviewer_issues': issues_data_from_code_reviewer,  # List of issues from code review
+        'project_uses_secure_properties': project_uses_secure_properties,  # Boolean flag from code review
+        'components_validator': components_validator_results  # Results from general component structure checks
     }
     
-    # Output combined results if needed
+    # Output the combined results dictionary. This can be consumed by other tools or scripts if needed.
     print("\nSummary of all validation results:", all_results)
 
 if __name__ == '__main__':
+    # This ensures main() is called only when the script is executed directly.
     main()

--- a/mule_validator/configfile_validator.py
+++ b/mule_validator/configfile_validator.py
@@ -1,77 +1,208 @@
+"""
+Validates MuleSoft YAML configuration files.
+
+This module checks for the presence of mandatory and optional YAML configuration
+files within a MuleSoft project's `src/main/resources` directory. It also
+validates the YAML syntax of these files and performs content-based checks
+to identify potential issues, such as plaintext secrets, especially considering
+whether the project utilizes Mule Secure Properties for encryption.
+"""
 import os
 import yaml
-from tabulate import tabulate
+import re
+# tabulate is not used in this module directly anymore.
+# It was likely used for printing results directly from this module before refactoring.
+# from tabulate import tabulate 
 
 def validate_yaml_file(file_path):
     """
-    Validates the YAML file at the given path.
+    Validates the basic YAML syntax of a single file.
 
     Args:
-        file_path (str): The path to the YAML file to validate.
+        file_path (str): The path to the YAML file.
 
     Returns:
-        tuple: (bool, str) - A tuple where the first element is a boolean indicating
-               if the file is valid, and the second element is an error message
-               if the file is invalid.
+        tuple: A tuple `(is_valid, error_message)`.
+               - `is_valid` (bool): True if the YAML syntax is valid, False otherwise.
+               - `error_message` (str or None): A string containing the YAML parsing
+                 error message if invalid, or None if valid.
     """
     try:
-        with open(file_path, 'r') as file:
+        with open(file_path, 'r', encoding='utf-8') as file: # Added encoding
             yaml.safe_load(file)
         return True, None
     except yaml.YAMLError as exc:
         return False, str(exc)
 
-def validate_files(package_folder_path):
+# Regex for detecting long, random-looking strings that might be unencrypted secrets.
+# This pattern looks for strings of 32+ characters containing alphanumeric chars and common Base64 chars.
+GENERIC_SECRET_PATTERN = re.compile(r'[a-zA-Z0-9+/=]{32,}')
+
+# Keywords that often indicate a property key is for a sensitive value.
+SENSITIVE_KEYWORDS = ['password', 'secret', 'key', 'token', 'credentials', 'apikey']
+
+def check_yaml_content_rules(file_path, project_uses_secure_properties):
     """
-    Validates the presence and syntax of YAML property files in the 
-    src/main/resources directory of the given MuleSoft package folder path.
+    Checks the content of a given YAML file for potential plaintext secrets or
+    misconfigurations related to sensitive data.
+
+    It uses a recursive helper to traverse nested YAML structures. Rules include:
+    - Identifying Mule encrypted values (e.g., `![...]`).
+    - Detecting values that match a generic pattern for secrets.
+    - Checking keys containing sensitive keywords for plaintext values.
+
+    The severity of reported issues (INFO vs. WARNING) can depend on whether
+    the project is configured to use Mule Secure Properties.
 
     Args:
-        package_folder_path (str): The path to the MuleSoft package folder.
+        file_path (str): The path to the YAML file to check.
+        project_uses_secure_properties (bool): True if the MuleSoft project is
+                                               configured to use secure properties.
+
+    Returns:
+        list: A list of issue description strings found in the YAML content.
     """
-    # Define mandatory and optional files
+    issues = []
+    try:
+        with open(file_path, 'r', encoding='utf-8') as file:
+            data = yaml.safe_load(file)
+    except Exception as e:
+        # If the file cannot be read or parsed, report this as a critical error for content validation.
+        issues.append(f"ERROR: Could not read or parse YAML file {file_path} for content validation: {e}")
+        return issues
+
+    if not data: # Handles empty or effectively empty (e.g., only comments) YAML files
+        return issues # No data to check, so no content issues.
+
+    def _find_issues_in_yaml_data(current_data, key_prefix=''):
+        """
+        Recursively traverses YAML data (dictionaries, lists, strings) to find issues.
+        
+        Args:
+            current_data: The current piece of YAML data (dict, list, or scalar).
+            key_prefix (str): The prefix for the current key, used to build full key paths
+                              for reporting (e.g., "api.credentials.username.").
+        """
+        if isinstance(current_data, dict):
+            # If it's a dictionary, iterate through its key-value pairs.
+            for key, value in current_data.items():
+                _find_issues_in_yaml_data(value, key_prefix + str(key) + ".")
+        elif isinstance(current_data, list):
+            # If it's a list, iterate through its items.
+            for index, item in enumerate(current_data):
+                _find_issues_in_yaml_data(item, key_prefix + str(index) + ".")
+        elif isinstance(current_data, str):
+            # If it's a string, apply the content validation rules.
+            value_str = current_data
+            # Construct the full key name for reporting (e.g., "db.password").
+            current_full_key_name = key_prefix[:-1] if key_prefix.endswith('.') else key_prefix
+            if not current_full_key_name: # Handle cases where a top-level value is a simple string
+                 current_full_key_name = "UnnamedTopLevelValue"
+
+
+            # Check if the value is Mule encrypted (starts with "![", ends with "]").
+            is_mule_encrypted = value_str.startswith("![") and value_str.endswith("]")
+            
+            # Check if the value matches a generic pattern for secrets (long, random-looking string).
+            is_potential_generic_secret = GENERIC_SECRET_PATTERN.match(value_str)
+
+            if is_mule_encrypted:
+                # Value is Mule encrypted.
+                if project_uses_secure_properties:
+                    # This is expected and good practice if the project uses secure properties.
+                    issues.append(f"INFO: Key '{current_full_key_name}' has a Mule encrypted value. Length (encrypted part): {len(value_str[2:-1])}.")
+                else:
+                    # This is unusual: value is encrypted, but no secure properties config was found project-wide.
+                    # This might indicate a misconfiguration or an incomplete setup.
+                    issues.append(f"WARNING: Key '{current_full_key_name}' has a Mule encrypted value, but Mule Secure Properties configuration was not detected project-wide.")
+            elif is_potential_generic_secret:
+                # Value is not Mule encrypted but matches a pattern that suggests it might be a secret.
+                issues.append(f"WARNING: Value for key '{current_full_key_name}' appears to be a generic secret/API key and is not Mule encrypted. Value excerpt: '{value_str[:10]}...'")
+
+            # Keyword-based check for sensitive data (only if not already Mule encrypted).
+            # This avoids redundant warnings if a sensitive key is already properly encrypted.
+            if not is_mule_encrypted:
+                key_lower = current_full_key_name.lower()
+                for keyword in SENSITIVE_KEYWORDS:
+                    if keyword in key_lower:
+                        # The key name itself suggests sensitivity (e.g., "password", "api.key").
+                        if project_uses_secure_properties:
+                            # Project supports encryption, but this specific sensitive key has a plaintext value.
+                            issues.append(f"WARNING: Key '{current_full_key_name}' (contains sensitive keyword '{keyword}') has a plaintext value, but the project supports Mule encryption. Consider encrypting. Value excerpt: '{value_str[:10]}...'")
+                        else:
+                            # Project does not support encryption, and this sensitive key has a plaintext value. High risk.
+                            issues.append(f"WARNING: Key '{current_full_key_name}' (contains sensitive keyword '{keyword}') may contain plaintext sensitive data, and the project does not appear to use Mule encryption. Value excerpt: '{value_str[:10]}...'")
+                        break # Found one sensitive keyword match for this key, no need to check others.
+
+    _find_issues_in_yaml_data(data) # Start the recursive check from the root of the YAML data.
+    return issues
+
+def validate_files(package_folder_path, project_uses_secure_properties):
+    """
+    Validates YAML property files in a MuleSoft project's `src/main/resources` directory.
+
+    This function checks for:
+    1. Presence of mandatory files (`config-prod.yaml`, `config-nonprod.yaml`).
+    2. YAML syntax validity of all found configuration files.
+    3. Content rules violations (e.g., plaintext secrets) using `check_yaml_content_rules`.
+
+    Args:
+        package_folder_path (str): The path to the root of the MuleSoft package.
+        project_uses_secure_properties (bool): A flag indicating whether the project
+                                               is configured to use Mule Secure Properties.
+                                               This affects how content rules are applied.
+    Returns:
+        list: A list of validation results. Each result is a list of three elements:
+              `[file_name, status, message]`.
+              - `file_name` (str): The name of the YAML file.
+              - `status` (str): Describes the validation status (e.g., 'Missing',
+                'Invalid Syntax', 'Valid Syntax', 'Content Issue').
+              - `message` (str): Detailed message about the issue or an empty string.
+    """
+    # Define standard YAML configuration files in MuleSoft projects.
     mandatory_files = ['config-prod.yaml', 'config-nonprod.yaml']
     optional_files = ['config-dev.yaml', 'config-uat.yaml', 'config-local.yaml']
     
-    # Build path to src/main/resources
+    # Construct the path to the standard resources directory.
     resources_folder_path = os.path.join(package_folder_path, 'src', 'main', 'resources')
     
-    # Check if resources directory exists
+    results = [] # Initialize list to store all validation results.
+
+    # Check if the resources directory actually exists.
     if not os.path.isdir(resources_folder_path):
-        print(f"Error: The specified path does not exist: {resources_folder_path}")
-        return
+        # If the resources directory is missing, report this and cannot proceed further.
+        results.append(['N/A', 'Directory Missing', f"Resources directory not found: {resources_folder_path}"])
+        return results 
     
-    # Collect results
-    results = []
-    all_files = mandatory_files + optional_files
+    all_files_to_check = mandatory_files + optional_files # Combine all files for iteration.
     
-    # Track if any files are found
-    any_files_found = False
-
-    for file_name in all_files:
+    for file_name in all_files_to_check:
         file_path = os.path.join(resources_folder_path, file_name)
+        
         if os.path.isfile(file_path):
-            any_files_found = True
-            is_valid, error = validate_yaml_file(file_path)
-            if file_name in mandatory_files:
-                if not is_valid:
-                    results.append([file_name, 'Invalid', error])
-                else:
-                    results.append([file_name, 'Valid', ''])
-            elif file_name in optional_files:
-                if not is_valid:
-                    results.append([file_name, 'Invalid', error])
-                else:
-                    results.append([file_name, 'Valid', ''])
+            # File exists, first validate its YAML syntax.
+            is_valid_syntax, syntax_error_message = validate_yaml_file(file_path)
+            
+            if not is_valid_syntax:
+                # If syntax is invalid, report it and do not proceed to content checks for this file.
+                results.append([file_name, 'Invalid Syntax', syntax_error_message])
+            else:
+                # Syntax is valid. Record this and proceed to content rule checks.
+                results.append([file_name, 'Valid Syntax', '']) 
+                
+                content_issues = check_yaml_content_rules(file_path, project_uses_secure_properties)
+                # Append each content issue found as a separate entry in the results.
+                for issue_message in content_issues:
+                    results.append([file_name, 'Content Issue', issue_message])
+                        
         elif file_name in mandatory_files:
-            results.append([file_name, 'Missing', 'File not found'])
+            # If a mandatory file is missing, report it.
+            results.append([file_name, 'Missing', 'Mandatory file not found'])
+            
+    return results # Return the aggregated list of all findings.
 
-    # Print results only if any YAML files were found
-    if any_files_found:
-        print(tabulate(results, headers=['File Name', 'Status', 'Error'], tablefmt='grid'))
-
-# Define the MuleSoft package folder path here
-#package_folder_path = 'c:/work/rnd/mulesoft-temp/sbs-ott-triggerintegrator'
+# Example usage (typically called from main.py or a similar orchestrator script)
+# package_folder_path = 'path/to/your/mulesoft/project'
 #package_folder_path = 'C:/Users/venkats/OneDrive - SBS Corporation/Documents/SBS/ws/mulesoft/' + 'sbs-mpx-mediamanagmentservices'
 #package_folder_path = 'C:/Users/venkats/OneDrive - SBS Corporation/Documents/SBS/ws/mulesoft/' + 'sbs-tbs-ingestmediainfo'
 #package_folder_path = 'C:/Users/venkats/OneDrive - SBS Corporation/Documents/SBS/ws/mulesoft/' + 'sbs-pnc-integrationservices'


### PR DESCRIPTION
I've implemented auto-detection of MuleSoft secure property configurations (<secure-properties:config>) within your project.

When detected, the validator adjusts its behavior:
- Generic secret pattern checks on property values are skipped if the value is in the Mule encrypted format (`![...]`), issuing an INFO message instead.
- Sensitive keyword checks (e.g., 'password' in key names) will result in an INFO message if the corresponding value is Mule-encrypted, rather than a standard warning.

This reduces false positives for correctly secured MuleSoft projects.

This includes:
- Logic changes in code_reviewer.py, main.py, configfile_validator.py.
- Updated code documentation (docstrings, comments).
- Updated README.md to explain the new feature.

Unit tests for this specific feature are being added next.