### PR TITLE
Refactor: Remove obsolete components_validator references

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,7 +10,6 @@ import argparse
 from mule_validator.dependency_validator import validate_dependencies_and_size
 from mule_validator.flow_validator import validate_flows_in_package
 from mule_validator.code_reviewer import review_all_files
-from mule_validator.components_validator import validate_mule_package
 from mule_validator.api_validator import validate_api_spec_and_flows
 from mule_validator.configfile_validator import validate_files
 from tabulate import tabulate
@@ -105,13 +104,6 @@ def main():
 
     # Note: Code Review (previously step 5 in some orderings) results were processed earlier.
 
-    # Step 6: Validate general Mule Components structure
-    print("\nValidating Components...")
-    components_validator_results = validate_mule_package(package_folder_path)
-    print("Components Validation Results:", components_validator_results)
-
-    
-
     # Combine all validation results into a single dictionary for a comprehensive summary.
     print("\nAll validations completed.")
     all_results = {
@@ -120,8 +112,7 @@ def main():
         'flow_validation': flow_validation_results,  # Results from Mule flow structure checks
         'api_validation': api_validation_results,  # Results from API spec vs. flow implementation checks
         'code_reviewer_issues': issues_data_from_code_reviewer,  # List of issues from code review
-        'project_uses_secure_properties': project_uses_secure_properties,  # Boolean flag from code review
-        'components_validator': components_validator_results  # Results from general component structure checks
+        'project_uses_secure_properties': project_uses_secure_properties  # Boolean flag from code review
     }
     
     # Output the combined results dictionary. This can be consumed by other tools or scripts if needed.

--- a/mule_validator/html_reporter.py
+++ b/mule_validator/html_reporter.py
@@ -99,11 +99,6 @@ def generate_html_report(all_results, template_string):
     else:
         html_content = html_content.replace('{{api_validation_results_table}}', "<p>No API validation data available or no issues found.</p>")
 
-    # 6. Components Validation Results
-    components_results = all_results.get('components_validator')
-    # `validate_mule_package` in `components_validator.py` returns a list of strings.
-    html_content = html_content.replace('{{components_validation_results_table}}', _format_data_to_html(components_results))
-
     # 7. Project Uses Mule Secure Properties
     secure_props_status = all_results.get('project_uses_secure_properties')
     html_content = html_content.replace('{{secure_properties_status}}', f"<p>{str(secure_props_status)}</p>")
@@ -114,7 +109,6 @@ def generate_html_report(all_results, template_string):
     html_content = html_content.replace('{{dependency_validation_results_table}}', "<p>Data not available.</p>")
     html_content = html_content.replace('{{flow_validation_results_table}}', "<p>Data not available.</p>")
     html_content = html_content.replace('{{api_validation_results_table}}', "<p>Data not available.</p>")
-    html_content = html_content.replace('{{components_validation_results_table}}', "<p>Data not available.</p>")
     html_content = html_content.replace('{{secure_properties_status}}', "<p>Data not available.</p>")
 
 


### PR DESCRIPTION
The components_validator.py file and its primary function validate_mule_package were identified as missing. I analyzed the situation and found that its intended functionality, described as "Validate general Mule Components structure," is largely covered by the existing comprehensive code_reviewer.py.

This commit removes all references to the obsolete components_validator and validate_mule_package from the following files:
- main.py (root directory): Removed import, function call, and results aggregation.
- mule_validator/html_reporter.py: Removed logic for processing and displaying results from components_validator.

These changes resolve the import error related to the missing file and streamline the validation process by removing redundant components.